### PR TITLE
Standardize spellings: draught -> draft; after effects -> aftereffects

### DIFF
--- a/src/epub/text/chapter-22.xhtml
+++ b/src/epub/text/chapter-22.xhtml
@@ -46,7 +46,7 @@
 			<p>“No sir,” said Nick, after a barely perceptible hesitation.</p>
 			<p>“You don’t think the cause could be in any way connected with, let us say, the emotional disturbances attending your acquaintance with Pat here?”</p>
 			<p>“No, sir,” said the youth flatly.</p>
-			<p>“All right,” said Horker. “Let that angle go for the present. Are there any after effects from these spells?”</p>
+			<p>“All right,” said Horker. “Let that angle go for the present. Are there any aftereffects from these spells?”</p>
 			<p>“Yes. There’s always a splitting headache.” He closed his eyes. “I have one of them now.”</p>
 			<p>“Localized?”</p>
 			<p>“Sir?”</p>

--- a/src/epub/text/chapter-29.xhtml
+++ b/src/epub/text/chapter-29.xhtml
@@ -11,7 +11,7 @@
 				<h2 epub:type="ordinal z3998:roman">XXIX</h2>
 				<p epub:type="title">Scopolamine for Satan</p>
 			</hgroup>
-			<p>The glass was struck from Pat’s hand, and the water-clear contents streamed into pools and darkening blots over the table and its litter of papers. She stared unseeingly at the mess, without realizing that it was Nick who had dashed the draught from her very lips. She felt neither anger nor relief, but only a numbness, and a sense of anticlimax. Somewhere below the bell was ringing again, and a door was resounding to violent blows, but she only continued her bewildered, questioning gaze.</p>
+			<p>The glass was struck from Pat’s hand, and the water-clear contents streamed into pools and darkening blots over the table and its litter of papers. She stared unseeingly at the mess, without realizing that it was Nick who had dashed the draft from her very lips. She felt neither anger nor relief, but only a numbness, and a sense of anticlimax. Somewhere below the bell was ringing again, and a door was resounding to violent blows, but she only continued her bewildered, questioning gaze.</p>
 			<p>“I can’t let you, Pat!” he muttered, answering her unspoken query.</p>
 			<p>“But Nick⁠—why?”</p>
 			<p>“There’s somebody at the door, isn’t there? Mustn’t we find out who?”</p>


### PR DESCRIPTION
Chapter 29 originally had ```draught```, which is the British spelling, but this is an American work that uses American spellings throughout. And ```draft``` appears in Chapter 31. The two spellings were used with the same sense.

Chapter 22 had both ```after effects``` and ```aftereffects```, with the same meaning. The closed-compound version (i.e., ```aftereffects```) is easier to look up in a dictionary, so I think it makes sense to change it to this spelling.